### PR TITLE
feat: Implement initial authentication endpoints (login and register)

### DIFF
--- a/openapi.api-description.yaml
+++ b/openapi.api-description.yaml
@@ -9,7 +9,6 @@ paths:
     post:
       tags:
         - Authentication
-        - Authorization
       operationId: login
       description: |
         Authenticates the User.
@@ -33,23 +32,11 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  accessToken:
-                    type: object
-                    properties:
-                      token:
-                        type: string
-                      expiresIn:
-                        type: integer
-                        format: int32
-                  refreshToken:
-                    type: string
+                $ref: "#/components/schemas/Tokens"
   /auth/register:
     post:
       tags:
         - Authentication
-        - Authorization
       operationId: register
       description: |
         Registers a new User.
@@ -80,15 +67,25 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  accessToken:
-                    type: object
-                    properties:
-                      token:
-                        type: string
-                      expiresIn:
-                        type: integer
-                        format: int32
-                  refreshToken:
-                    type: string
+                $ref: "#/components/schemas/Tokens"
+components:
+  schemas:
+    Tokens:
+      type: object
+      properties:
+        accessToken:
+          type: object
+          properties:
+            token:
+              type: string
+            expiresIn:
+              type: integer
+              format: int32
+        refreshToken:
+          type: object
+          properties:
+            token:
+              type: string
+            expiresIn:
+              type: integer
+              format: int32

--- a/openapi.api-description.yaml
+++ b/openapi.api-description.yaml
@@ -1,7 +1,94 @@
-openapi: 3.1.0
+openapi: 3.0.3
 info:
   title: TheJebProject API Description
   description: |
-    This API will be used to power TheJebProject frontends.
-  version: 0.0.1
+    TheJebProject Backend API Description
+  version: 0.1.0
 paths:
+  /auth/login:
+    post:
+      tags:
+        - Authentication
+        - Authorization
+      operationId: login
+      description: |
+        Authenticates the User.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                password:
+                  type: string
+                  format: password
+              required:
+                - email
+                - password
+      responses:
+        "200":
+          description: Login Successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  accessToken:
+                    type: object
+                    properties:
+                      token:
+                        type: string
+                      expiresIn:
+                        type: integer
+                        format: int32
+                  refreshToken:
+                    type: string
+  /auth/register:
+    post:
+      tags:
+        - Authentication
+        - Authorization
+      operationId: register
+      description: |
+        Registers a new User.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                firstName:
+                  type: string
+                lastName:
+                  type: string
+                email:
+                  type: string
+                password:
+                  type: string
+                  format: password
+              required:
+                - firstName
+                - lastName
+                - email
+                - password
+      responses:
+        "200":
+          description: |
+            Registration Successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  accessToken:
+                    type: object
+                    properties:
+                      token:
+                        type: string
+                      expiresIn:
+                        type: integer
+                        format: int32
+                  refreshToken:
+                    type: string


### PR DESCRIPTION
This pull request introduces the initial authentication endpoints for TheJebProject API, as described in the provided OpenAPI specification.

**Key changes:**

- Implemented the `/auth/login` POST endpoint for user authentication using email and password. Upon successful authentication, it returns a set of access and refresh tokens.
- Implemented the `/auth/register` POST endpoint for new user registration, requiring `firstName`, `lastName`, `email`, and `password`. Successful registration also returns a set of access and refresh tokens.
- Defined the `Tokens` schema in the `components/schemas` section to structure the response for both login and registration. This schema includes `accessToken` and `refreshToken`, each containing a `token` string and an `expiresIn` integer (int32).